### PR TITLE
fix displaying of error message to properly show the exception details

### DIFF
--- a/python/semantic_kernel/processes/local_runtime/local_process.py
+++ b/python/semantic_kernel/processes/local_runtime/local_process.py
@@ -186,7 +186,7 @@ class LocalProcess(LocalStep):
                 await asyncio.gather(*message_tasks)
 
         except Exception as ex:
-            print("An error occurred while running the process: %s.", ex)
+            print("An error occurred while running the process: %s." % ex)
             raise
 
     async def to_kernel_process(self) -> "KernelProcess":


### PR DESCRIPTION
### Motivation and Context

This change is required to properly print exception details when logging an error message, which helps debugging.

### Description

Fixes printing of debugging information used [here](https://github.com/microsoft/semantic-kernel/blob/db45cfa7cf1b0f00aa3b1414e4d018ba816b8960/python/semantic_kernel/processes/local_runtime/local_process.py#L189) where the exception details were ignored due to the usage of bad syntax.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
